### PR TITLE
Speedup examples (and clairify one)

### DIFF
--- a/cfile-to-asm-builder/SConstruct
+++ b/cfile-to-asm-builder/SConstruct
@@ -1,3 +1,7 @@
+# Skip initializing any tools in the DefaultEnvironment 
+# as we're not using it.
+DefaultEnvironment(tools=[])
+
 # Create a new method to generate assembly files.
 env=Environment()
 

--- a/shared-lib-program/SConstruct
+++ b/shared-lib-program/SConstruct
@@ -9,13 +9,13 @@ env.SharedLibrary(
     target = libname,
     source = 'lib.c')
     
-# We list the library by it's base name 'a' and not a.dll, or liba.a because SCons
+# We list the library by it's base name 'xyz' and not xyz.dll, or libxyz.a because SCons
 # will expand this to the appropriate platform/compiler dependent file name 
-# and use the correct arguments to the linker to link against the shared library 'a'
-# NOTE: We use LIBS here instead of env['LIBS']=['a'] as we're also building the
+# and use the correct arguments to the linker to link against the shared library 'xyz'
+# NOTE: We use LIBS here instead of env['LIBS']=['xyz'] as we're also building the
 #       shared library above with the same Environment().
-#       Having env.Prepend(LIBS=['a']) would cause the SharedLibrary() above to ALSO
-#       try to link against shared library a. (Or on win32 file 'a.lib') and fail.
+#       Having env.Prepend(LIBS=['xyz']) would cause the SharedLibrary() above to ALSO
+#       try to link against shared library xyz. (Or on win32 file 'xyz.lib') and fail.
 env.Program(
     target = 'app',
     source = 'app.c',

--- a/simple-configure/SConstruct
+++ b/simple-configure/SConstruct
@@ -1,3 +1,7 @@
+# Skip initializing any tools in the DefaultEnvironment 
+# as we're not using it.
+DefaultEnvironment(tools=[])
+
 env=Environment()
 
 conf=Configure(env, config_h='config.h')

--- a/simple-variant-dir/SConstruct
+++ b/simple-variant-dir/SConstruct
@@ -1,3 +1,7 @@
+# Skip initializing any tools in the DefaultEnvironment 
+# as we're not using it.
+DefaultEnvironment(tools=[])
+
 env=Environment()
 
 env['CPPPATH'] = ['#/src/liba']

--- a/simple/SConstruct
+++ b/simple/SConstruct
@@ -1,2 +1,6 @@
+# Skip initializing any tools in the DefaultEnvironment 
+# as we're not using it.
+DefaultEnvironment(tools=[])
+
 env=Environment()
 env.Program('hello.c')


### PR DESCRIPTION
Add code to skip initializing DefaultEnvironment() when it's clear it won't be used. This will significantly speed up these examples on windows